### PR TITLE
Add promotional sections and urgency

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import Header from './components/Header';
+import PromoBanner from './components/PromoBanner';
 import Hero from './components/Hero';
+import MediaBanner from './components/MediaBanner';
 import Benefits from './components/Benefits';
+import HowItWorks from './components/HowItWorks';
 import Features from './components/Features';
 import Testimonials from './components/Testimonials';
 import ComparisonTable from './components/ComparisonTable';
@@ -12,10 +15,13 @@ import Footer from './components/Footer';
 function App() {
   return (
     <div className="font-sans text-gray-800 bg-gray-50">
+      <PromoBanner />
       <Header />
       <main>
         <Hero />
+        <MediaBanner />
         <Benefits />
+        <HowItWorks />
         <Features />
         <Testimonials />
         <ComparisonTable />
@@ -28,3 +34,4 @@ function App() {
 }
 
 export default App;
+

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -1,7 +1,25 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ShieldCheck, Package, Zap } from 'lucide-react';
 
 const CallToAction: React.FC = () => {
+  const [timeLeft, setTimeLeft] = useState<number>(0);
+
+  useEffect(() => {
+    const target = new Date();
+    target.setHours(target.getHours() + 6);
+
+    const interval = setInterval(() => {
+      const diff = target.getTime() - new Date().getTime();
+      setTimeLeft(diff > 0 ? diff : 0);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const hours = Math.floor(timeLeft / 1000 / 3600);
+  const minutes = Math.floor(timeLeft / 1000 / 60) % 60;
+  const seconds = Math.floor(timeLeft / 1000) % 60;
+
   return (
     <section className="py-16 bg-white">
       <div className="max-w-4xl mx-auto px-4">
@@ -9,9 +27,12 @@ const CallToAction: React.FC = () => {
           <h2 className="text-3xl md:text-4xl font-bold mb-6">
             Special Limited Time Offer
           </h2>
-          <p className="text-xl text-gray-600">
+          <p className="text-xl text-gray-600 mb-2">
             Order today and save over 50% off retail price
           </p>
+          <div className="text-red-600 font-semibold">
+            Offer ends in {hours}h {minutes}m {seconds}s
+          </div>
         </div>
 
         <div className="bg-gray-50 rounded-2xl p-8 mb-12">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -80,6 +80,7 @@ const Footer: React.FC = () => {
               <a href="#" className="text-gray-400 hover:text-white transition-colors text-sm">Privacy Policy</a>
               <a href="#" className="text-gray-400 hover:text-white transition-colors text-sm">Terms of Service</a>
               <a href="#" className="text-gray-400 hover:text-white transition-colors text-sm">Returns</a>
+              <a href="#" className="text-gray-400 hover:text-white transition-colors text-sm">Contact Us</a>
             </div>
           </div>
         </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,45 +1,64 @@
 import React from 'react';
-import { ShieldCheck } from 'lucide-react';
+import { ShieldCheck, Star } from 'lucide-react';
 
 const Hero: React.FC = () => {
   return (
     <section className="pt-24 pb-16 px-4">
-      <div className="max-w-4xl mx-auto text-center">
-        <h1 className="text-4xl md:text-5xl font-bold mb-6 leading-tight">
-          Finally, An Affordable Hearing Aid That
-          <span className="gradient-text block mt-2">Actually Works</span>
-        </h1>
-        
-        <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
-          Experience crystal-clear sound without the $2,000+ price tag. 
-          No prescription needed. Try risk-free for 120 days.
-        </p>
+      <div className="max-w-6xl mx-auto flex flex-col-reverse md:flex-row items-center gap-12">
+        <div className="md:w-1/2 text-center md:text-left">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4 leading-tight">
+            Finally, An Affordable Hearing Aid That
+            <span className="gradient-text block mt-2">Actually Works</span>
+          </h1>
+          <h2 className="text-lg md:text-xl text-primary font-semibold mb-4">
+            Limited Time Offer: Order Today And Save 50%
+          </h2>
 
-        <div className="flex flex-col items-center gap-6 mb-12">
-          <button className="btn-primary text-white text-xl font-semibold py-4 px-8 rounded-full w-full max-w-md">
-            Get Your Claritone Today
-          </button>
-          
-          <div className="flex items-center gap-2 text-gray-600">
-            <ShieldCheck className="h-5 w-5 text-primary" />
-            <span>120-Day Money Back Guarantee</span>
+          <p className="text-xl text-gray-600 mb-6 max-w-xl">
+            Experience crystal-clear sound without the $2,000+ price tag. No prescription needed. Try risk-free for 120 days.
+          </p>
+
+          <div className="flex justify-center md:justify-start mb-4">
+            {[...Array(5)].map((_, i) => (
+              <Star key={i} className="h-5 w-5 text-yellow-400 fill-current" />
+            ))}
+            <span className="ml-2 text-gray-600">Rated 4.8/5 by 50,000+ users</span>
+          </div>
+
+          <div className="flex flex-col items-center md:items-start gap-4 mb-8">
+            <button className="btn-primary text-white text-xl font-semibold py-4 px-8 rounded-full w-full max-w-md">
+              Get Your Claritone Today
+            </button>
+
+            <div className="flex items-center gap-2 text-gray-600">
+              <ShieldCheck className="h-5 w-5 text-primary" />
+              <span>120-Day Money Back Guarantee</span>
+            </div>
           </div>
         </div>
 
-        <div className="bg-gray-50 rounded-2xl p-8 max-w-3xl mx-auto">
-          <div className="grid grid-cols-3 gap-6 text-center">
-            <div>
-              <div className="text-3xl font-bold text-primary mb-2">50,000+</div>
-              <div className="text-gray-600">Happy Customers</div>
-            </div>
-            <div>
-              <div className="text-3xl font-bold text-primary mb-2">4.8/5</div>
-              <div className="text-gray-600">Average Rating</div>
-            </div>
-            <div>
-              <div className="text-3xl font-bold text-primary mb-2">120</div>
-              <div className="text-gray-600">Day Guarantee</div>
-            </div>
+        <div className="md:w-1/2 flex justify-center mb-8 md:mb-0">
+          <img
+            src="https://images.pexels.com/photos/5699424/pexels-photo-5699424.jpeg"
+            alt="Claritone hearing aid"
+            className="w-full max-w-sm rounded-xl shadow-xl"
+          />
+        </div>
+      </div>
+
+      <div className="bg-gray-50 rounded-2xl p-8 mt-12 max-w-3xl mx-auto">
+        <div className="grid grid-cols-3 gap-6 text-center">
+          <div>
+            <div className="text-3xl font-bold text-primary mb-2">50,000+</div>
+            <div className="text-gray-600">Happy Customers</div>
+          </div>
+          <div>
+            <div className="text-3xl font-bold text-primary mb-2">4.8/5</div>
+            <div className="text-gray-600">Average Rating</div>
+          </div>
+          <div>
+            <div className="text-3xl font-bold text-primary mb-2">120</div>
+            <div className="text-gray-600">Day Guarantee</div>
           </div>
         </div>
       </div>

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { ShoppingCart, PackageCheck, Smile } from 'lucide-react';
+
+const steps = [
+  {
+    icon: <ShoppingCart className="h-6 w-6" />,
+    title: 'Order Claritone',
+    text: 'Choose your package and place your secure order.'
+  },
+  {
+    icon: <PackageCheck className="h-6 w-6" />,
+    title: 'Receive Quickly',
+    text: 'We ship within 24 hours. Enjoy free shipping.'
+  },
+  {
+    icon: <Smile className="h-6 w-6" />,
+    title: 'Hear Clearly',
+    text: 'Put them on, adjust the volume and rediscover conversations.'
+  }
+];
+
+const HowItWorks: React.FC = () => (
+  <section className="py-20 bg-gray-50">
+    <div className="container mx-auto px-4">
+      <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
+        How <span className="gradient-text">It Works</span>
+      </h2>
+      <div className="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+        {steps.map((step, i) => (
+          <div key={i} className="bg-white p-6 rounded-xl shadow-sm text-center">
+            <div className="flex items-center justify-center w-12 h-12 bg-primary/10 text-primary rounded-full mx-auto mb-4">
+              {step.icon}
+            </div>
+            <h3 className="font-semibold mb-2">{step.title}</h3>
+            <p className="text-gray-600">{step.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default HowItWorks;
+

--- a/src/components/MediaBanner.tsx
+++ b/src/components/MediaBanner.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const MediaBanner: React.FC = () => (
+  <section className="bg-white py-4">
+    <div className="container mx-auto px-4 flex flex-wrap items-center justify-center gap-6">
+      <span className="text-sm font-semibold text-gray-500">As seen on</span>
+      <img src="https://via.placeholder.com/100x40?text=TV+1" alt="TV1" className="h-6" />
+      <img src="https://via.placeholder.com/100x40?text=TV+2" alt="TV2" className="h-6" />
+      <img src="https://via.placeholder.com/100x40?text=TV+3" alt="TV3" className="h-6" />
+    </div>
+  </section>
+);
+
+export default MediaBanner;
+

--- a/src/components/PromoBanner.tsx
+++ b/src/components/PromoBanner.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const PromoBanner: React.FC = () => (
+  <div className="bg-primary text-white text-sm text-center py-2">
+    Hurry! Limited stock available today.
+  </div>
+);
+
+export default PromoBanner;
+

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -23,6 +23,20 @@ const Testimonials: React.FC = () => {
       age: 63,
       location: "California",
       rating: 5
+    },
+    {
+      quote: "The sound quality is fantastic and the price can't be beat.",
+      author: "Linda W.",
+      age: 58,
+      location: "New York",
+      rating: 5
+    },
+    {
+      quote: "I was skeptical at first but Claritone really works. Highly recommended!",
+      author: "Paul T.",
+      age: 70,
+      location: "Ohio",
+      rating: 5
     }
   ];
 


### PR DESCRIPTION
## Summary
- update hero section with product image and ratings
- add promo/limited stock banner
- show media logos for extra social proof
- include a new How It Works section
- expand testimonials and footer links
- add countdown timer in the call-to-action section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_683ec06c9f748321917e717398df64b1