### PR TITLE
Add Jest and smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # LPhearingaids
 Lamding page for hearing aids
+
+## Running tests
+
+```
+npm test
+```

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "echo 'skipping lint'",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -24,6 +25,11 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.6.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import App from './App';
+
+test('renders promo banner text', () => {
+  render(<App />);
+  expect(screen.getByText(/limited stock available today/i)).toBeInTheDocument();
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- set up Jest and React Testing Library
- add Jest config and setup
- write smoke test for `<App />`
- document how to run the tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f06be954c83218f8b85718be75a48